### PR TITLE
fix: Using pip instead of poetry to init the project was causing errors

### DIFF
--- a/packages/extraction/setup.py
+++ b/packages/extraction/setup.py
@@ -7,7 +7,7 @@ setuptools.setup(
     name="mlopspython-extraction",
     version="0.0.0",
     packages=["mlopspython_extraction"],
-    package_dir={"": ""},
+    package_dir={"mlopspython_extraction": "./mlopspython_extraction"},
     package_data={"mlopspython_extraction": ["*"]},
     install_requires=requirements,
     author="Guillaume Chervet",

--- a/packages/inference/setup.py
+++ b/packages/inference/setup.py
@@ -7,7 +7,7 @@ setuptools.setup(
     name="mlopspython-inference",
     version="0.0.0",
     packages=["mlopspython_inference"],
-    package_dir={"": ""},
+    package_dir={"mlopspython_inference": "./mlopspython_inference"},
     package_data={"mlopspython_inference": ["*"]},
     install_requires=requirements,
     author="Guillaume Chervet",

--- a/pip-install.sh
+++ b/pip-install.sh
@@ -20,7 +20,7 @@ cp *.whl ../../../production/api/packages
 cd $cwd
 
 echo "Install packages Extraction"
-python -m python -m pip install -e packages/extraction
+python -m pip install -e packages/extraction
 
 cd packages/extraction/
 python setup.py sdist bdist_wheel


### PR DESCRIPTION
Project initialization using pip was causing errors. Those errors prevented the API from starting up.

# Before this PR

```sh
$ ./Makefile pip 0.2.0

Installing with pip (degraded mode)
[...]
Install packages Inference
[...]
Successfully built mlopspython_inference
[...]
running sdist
running egg_info

# This error was fixed in commit 2750395
error: error in 'egg_base' option: '' does not exist or is not a directory

./pip-install.sh: line 16: cd: dist: No such file or directory
cp: *.whl: No such file or directory
cp: *.whl: No such file or directory
Install packages Extraction

# This error was fixed in commit 969f0d0
/Users/number/Perso/MLOpsPython/venv_mlops/bin/python: No module named python

running sdist
running egg_info

# This error was fixed in commit 2750395
error: error in 'egg_base' option: '' does not exist or is not a directory

./pip-install.sh: line 27: cd: dist: No such file or directory
cp: *.whl: No such file or directory
cp: *.whl: No such file or directory
```

# After this PR

```
$ ./Makefile pip 0.2.0

Installing with pip (degraded mode)
[...]
Install packages Inference
[...]
Successfully built mlopspython_inference
[...]
Successfully installed mlopspython_inference-0.0.0
[...]
Install packages Extraction
[...]
Successfully built mlopspython_extraction
[...]
Successfully installed mlopspython_extraction-0.0.0
```